### PR TITLE
Fix release notes to include only current version's changes

### DIFF
--- a/.github/workflows/release-consolidated.yml
+++ b/.github/workflows/release-consolidated.yml
@@ -66,12 +66,15 @@ jobs:
     - name: Install git-cliff
       run: cargo install git-cliff
 
-    - name: Generate release notes
       run: |
         TAG="${{ steps.tag.outputs.tag }}"
         
-        # Generate base changelog
-        git cliff --tag "$TAG" --strip header > base_notes.md
+        # Generate changelog for current tag
+        git cliff --tag $TAG > base_notes.md
+
+        
+        # Remove the version header line to match original format
+        sed -i '1d' base_notes.md
         
         # Create enhanced release notes
         cat > enhanced_notes.md << EOF


### PR DESCRIPTION
## Summary
- Updated the release workflow to use git-cliff --tag option for generating changelog, ensuring release notes contain only changes for the current version.