### PR TITLE
Update release workflow to extract only current version's changelog section

### DIFF
--- a/.github/workflows/release-consolidated.yml
+++ b/.github/workflows/release-consolidated.yml
@@ -69,18 +69,30 @@ jobs:
       run: |
         TAG="${{ steps.tag.outputs.tag }}"
         
-        # Generate changelog for current tag
-        git cliff --tag $TAG > base_notes.md
-
+        # Generate changelog for current tag and extract only current version section
+        TAG_NO_V=$(echo $TAG | sed 's/^v//')
+        git cliff --tag $TAG | awk "/^## \\[$TAG_NO_V\\]/ { found=1; print; next } /^##/ && found { exit } found { print }" > base_notes.md
+        
         
         # Remove the version header line to match original format
         sed -i '1d' base_notes.md
+        # Get previous tag and commit summary
+        PREV_TAG=$(git describe --tags --abbrev=0 HEAD~1 2>/dev/null || echo "")
+        if [ -n "$PREV_TAG" ]; then
+          COMMIT_SUMMARY=$(git log --oneline $PREV_TAG..$TAG)
+        else
+          COMMIT_SUMMARY="Initial release - no previous commits to summarize."
+        fi
         
         # Create enhanced release notes
         cat > enhanced_notes.md << EOF
         ## Code Guardian $TAG 🛡️
         
         $(cat base_notes.md)
+        
+        ### 📝 Commit Summary
+        
+        $COMMIT_SUMMARY
         
         ### 📦 Installation
         


### PR DESCRIPTION
## Summary

- Update the release-consolidated.yml workflow to extract only the current version's changelog section using awk filtering.
- Add a commit summary section to the enhanced release notes for better visibility of changes.

This ensures release notes are more focused and include relevant commit information.